### PR TITLE
chore: typings declarations for DB querying

### DIFF
--- a/types/api.ts
+++ b/types/api.ts
@@ -1,53 +1,61 @@
-import { StringMap, Primitive } from "./common";
+import { StringMap, Primitive, TypeResult } from "./common";
 
-export type StrapiRequestContext<TBody extends {}, TQuery = {}> = {
-    request: StrapiRequest<TBody>
-    query: TQuery
-    params: StringMap<string | number>
-    
-    send: Function
-    throw: Function
-}
+type SendStrapiContextFunction = (...args: unknown[]) => void;
+
+type ThrowStrapiContextFunction = (...args: unknown[]) => void;
+
+export type StrapiRequestContext<
+  TBody = StringMap<string | number>,
+  TQuery = StringMap<string | number>,
+  TParams = StringMap<string | number>
+> = {
+  request: StrapiRequest<TBody>;
+  query: TQuery;
+  params: TParams;
+  send: SendStrapiContextFunction;
+  throw: ThrowStrapiContextFunction;
+};
 
 export type StrapiRequest<TBody extends {}> = {
-    body?: TBody
+  body?: TBody;
 };
 
 export type StrapiPagination = {
-    page?: number
-    pageSize?: number
-    start?: number
-    limit?: number
-    withCount?: boolean | string
+  page?: number;
+  pageSize?: number;
+  start?: number;
+  limit?: number;
+  withCount?: boolean | string;
 };
 
+export type StrapiResponseMetaPagination = TypeResult<
+  Pick<StrapiPagination, "page" | "pageSize" | "start" | "limit"> & {
+    pageCount?: number;
+    total?: number;
+  }
+>;
+
 export type StrapiResponseMeta = {
-    pagination: Pick<StrapiPagination, 'page' | 'pageSize' |'start' | 'limit'> & { 
-        pageCount?: number
-        total?: number
-    }
+  pagination: StrapiResponseMetaPagination;
 };
 
 export type StrapiPaginatedResponse<T> = {
-    data: Array<T>
-    meta?: StrapiResponseMeta
+  data: Array<T>;
+  meta?: StrapiResponseMeta;
 };
 
+export type StrapiQueryParams = StringMap<string>;
 
-export type StrapiQueryParams = {
-    [key: string]: string
-};
-
-export type StrapiQueryParamsParsed = {
-    [key: string]: Primitive
-};
+export type StrapiQueryParamsParsed = StringMap<Primitive>;
 
 export type StrapiQueryParamsParsedOrderBy = string | Array<string>;
 
-type StrapiQueryParamsParsedFilterValue = Primitive | {
-    [key: string]: StrapiQueryParamsParsedFilterValue;
-};
+type StrapiQueryParamsParsedFilterValue =
+  | Primitive
+  | {
+      [key: string]: StrapiQueryParamsParsedFilterValue;
+    };
 
 export type StrapiQueryParamsParsedFilters = {
-    [key: string]: StrapiQueryParamsParsedFilterValue;
+  [key: string]: StrapiQueryParamsParsedFilterValue;
 };

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -2,16 +2,14 @@ export type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
 
 export type Primitive = string | number | object | boolean | null | undefined;
 
-export type KeyValueSet<T> = {
-    [key: string]: T | any
-};
+export type KeyValueSet<T> = Record<string, T | any>;
 
-export type Method = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-export type StringMap<Type> = Record<string, Type>
+export type StringMap<Type> = Record<string, Type>;
 
-export type TypeResult<T extends Object> = {
-[K in keyof T]: T[K];
+export type TypeResult<T> = {
+  [K in keyof T]: T[K];
 };
 
 export type Id = number | string;

--- a/types/contentType.ts
+++ b/types/contentType.ts
@@ -1,3 +1,1 @@
-export type StrapiContentTypeSchema = {
-
-}
+export type StrapiContentTypeSchema = {};

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -1,57 +1,57 @@
-import { StringMap } from "./common"
-import { StrapiContentTypeSchema } from "./contentType"
+import { HTTPMethod, StringMap, TypeResult } from "./common";
+import { StrapiContentTypeSchema } from "./contentType";
 
 export interface IStrapi {
-    config: StrapiConfigContainer
-    EE(): Function
-    get services(): StringMap<StrapiService>
-    service(uid: string): StrapiService
-    get controllers(): StringMap<StrapiController>
-    controller(uid: string): StrapiController
-    get contentTypes(): StringMap<StrapiContentType>
-    contentType(name: string): StrapiContentType
-    get policies(): StringMap<StrapiPolicy>
-    policy(name: string): StrapiPolicy
-    get middlewares(): StringMap<StrapiMiddleware>
-    middleware(name: string): StrapiMiddleware
-    get plugins(): StringMap<StrapiPlugin>
-    plugin(name: string): StrapiPlugin
-    get hooks(): StringMap<StrapiHook>
-    hook(name: string): StrapiHook
-    api(): StringMap<StrapiApi>
-    api(name: string): StrapiApi
-    auth(): StrapiAuth
-    getModel<T>(uid: string): StrapiContentType<T>
-    query<T>(uid: string): StrapiDBQuery<T>
-    store(props: StrapiStoreQuery): StrapiStore
-    get components(): StringMap<any>
+    config: StrapiConfigContainer;
+    EE(): Function;
+    get services(): StringMap<StrapiService>;
+    service(uid: string): StrapiService;
+    get controllers(): StringMap<StrapiController>;
+    controller(uid: string): StrapiController;
+    get contentTypes(): StringMap<StrapiContentType>;
+    contentType(name: string): StrapiContentType;
+    get policies(): StringMap<StrapiPolicy>;
+    policy(name: string): StrapiPolicy;
+    get middlewares(): StringMap<StrapiMiddleware>;
+    middleware(name: string): StrapiMiddleware;
+    get plugins(): StringMap<StrapiPlugin>;
+    plugin(name: string): StrapiPlugin;
+    get hooks(): StringMap<StrapiHook>;
+    hook(name: string): StrapiHook;
+    api(): StringMap<StrapiApi>;
+    api(name: string): StrapiApi;
+    auth(): StrapiAuth;
+    getModel<T>(uid: string): StrapiContentType<T>;
+    query<T>(uid: string): StrapiDBQuery<T>;
+    store(props: StrapiStoreQuery): StrapiStore;
+    get components(): StringMap<any>;
 
-    start: Function
-    destroy: Function
-    sendStartupTelemetry: Function
-    openAdmin: Function
-    postListen: Function
-    listen: Function
-    stopWithError: Function
-    stop: Function
-    loadAdmin: Function
-    loadPlugins: Function
-    loadPolicies: Function
-    loadAPIs: Function
-    loadComponents: Function
-    loadMiddlewares: Function
-    loadApp: Function
-    registerInternalHooks: Function
-    register: Function
-    bootstrap: Function
-    load: Function
-    startWebhooks: Function
-    reload: Function
-    runLifecyclesFunctions: Function
+    start: Function;
+    destroy: Function;
+    sendStartupTelemetry: Function;
+    openAdmin: Function;
+    postListen: Function;
+    listen: Function;
+    stopWithError: Function;
+    stop: Function;
+    loadAdmin: Function;
+    loadPlugins: Function;
+    loadPolicies: Function;
+    loadAPIs: Function;
+    loadComponents: Function;
+    loadMiddlewares: Function;
+    loadApp: Function;
+    registerInternalHooks: Function;
+    register: Function;
+    bootstrap: Function;
+    load: Function;
+    startWebhooks: Function;
+    reload: Function;
+    runLifecyclesFunctions: Function;
 
-    db: StrapiDB
-    admin: StrapiAdmin
-    log: StrapiLog
+    db: StrapiDB;
+    admin: StrapiAdmin;
+    log: StrapiLog;
 }
 
 export type StrapiService = any;
@@ -63,77 +63,133 @@ export type StrapiHook = Object;
 export type StrapiApi = Object;
 export type StrapiAuth = Object;
 export type StrapiPlugin = {
-    get services(): StringMap<StrapiService>
-    service(uid: string): StrapiService
-    get controllers(): StringMap<StrapiController>
-    controller(name: string): StrapiController
-    get contentTypes(): StringMap<any>
-    contentType(name: string): StrapiContentType
-    config(name: string): any
+    get services(): StringMap<StrapiService>;
+    service(uid: string): StrapiService;
+    get controllers(): StringMap<StrapiController>;
+    controller(name: string): StrapiController;
+    get contentTypes(): StringMap<any>;
+    contentType(name: string): StrapiContentType;
+    config(name: string): any;
 };
 
-export type StrapiPluginConfig<Type> = {
-    [Property in keyof Type]: Type[Property];
-};
+export type StrapiPluginConfig<T> = TypeResult<T>;
 
 export type StrapiConfigContainer = StringMap<any> & {
-    get: Function
-}
+    get: Function;
+};
 
 export type StrapiStore = {
-    get: Function
-    set: Function
-    delete: Function
-}
+    get: Function;
+    set: Function;
+    delete: Function;
+};
 
 export type StrapiStoreQuery = {
-    type: string
-    name?: string
+    type: string;
+    name?: string;
 };
 
 export type StrapiDB = {
-    query<T>(uid: string): StrapiDBQuery<T>
+    query<T>(uid: string): StrapiDBQuery<T>;
 };
 
-export type StrapiDBQuery<T> = {
-    findOne(args: number | string | StrapiDBQueryArgs): Promise<T>
-    findMany(args?: StrapiDBQueryArgs): Promise<Array<T>>
-    findWithCount(args: StrapiDBQueryArgs): Promise<[items: Array<T>, count: number]>
-    create(args: StrapiDBQueryArgs): Promise<T>
-    createMany(args: StrapiDBQueryArgs): Promise<Array<T>>
-    update(args: StrapiDBQueryArgs): Promise<T>
-    updateMany(args: StrapiDBQueryArgs): Promise<Array<T>>
-    delete(args: StrapiDBQueryArgs): Promise<T>
-    deleteMany(args: StrapiDBQueryArgs): Promise<Array<T>>
-    count(args?: StrapiDBQueryArgs): number
+export type StrapiDBQuery<TValue, TKeys = keyof TValue> = {
+    findOne(args: number | string | StrapiDBQueryArgs): Promise<TValue>;
+    findMany(args?: StrapiDBQueryArgs<TKeys>): Promise<Array<TValue>>;
+    findWithCount(
+        args: StrapiDBQueryArgs<TKeys>
+    ): Promise<[items: Array<TValue>, count: number]>;
+    create(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
+    createMany(args: StrapiDBQueryArgs<TKeys>): Promise<Array<TValue>>;
+    update(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
+    updateMany(args: StrapiDBQueryArgs<TKeys>): Promise<Array<TValue>>;
+    delete(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
+    deleteMany(args: StrapiDBQueryArgs<TKeys>): Promise<Array<TValue>>;
+    count(args?: StrapiDBQueryArgs<TKeys>): number;
 };
 
-export type StrapiDBQueryArgs = {
-    where?: StringMap<>
-    data?: any
-    offset?: number
-    limit?: number
-    populate?: any
-    orderBy?: string | Array<any>
-}
+// https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.html#logical-operators
 
-export type StrapiAdmin = any
+type EqualWhereOperator<T = unknown> = { $eq: T };
+type NotEqualWhereOperator<T = unknown> = { $ne: T };
+type InWhereOperator<T = string> = { $in: Array<T> };
+type NotInWhereOperator<T = string> = { $notIn: Array<T> };
+type LessThanWhereOperator = { $lt: number };
+type LessThanEqualWhereOperator = { $lte: number };
+type GreaterThanWhereOperator = { $gt: number };
+type GreaterThanEqualWhereOperator = { $gte: number };
+type BetweenWhereOperator = { $between: Array<number> };
+type ContainsWhereOperator = { $contains: string };
+type NotContainsWhereOperator = { $notContains: string };
+type ContainsCaseInsensitiveWhereOperator = { $containsi: string };
+type NotContainsCaseInsensitiveWhereOperator = { $notContainsi: string };
+type StartsWithWhereOperator = { $startsWith: string };
+type EndsWithWhereOperator = { $endsWith: string };
+type EndsWithWhereOperator = { $endsWith: string };
+type IsNullWhereOperator = { $null: boolean };
+type IsNotNullWhereOperator = { $notNull: boolean };
+type NotWhereOperator<TKey extends string, TValue> = {
+    $not: {
+        [TKey]: [TValue];
+    };
+};
+type AndWhereOperator<T> = { $and: T[] };
+type OrWhereOperator<T> = { $or: T[] };
+
+type WhereOperator<T = unknown> =
+    | T
+    | EqualWhereOperator<T>
+    | NotEqualWhereOperator<T>
+    | InWhereOperator<T>
+    | NotInWhereOperator<T>
+    | LessThanWhereOperator
+    | LessThanEqualWhereOperator
+    | GreaterThanWhereOperator
+    | GreaterThanEqualWhereOperator
+    | BetweenWhereOperator
+    | ContainsWhereOperator
+    | NotContainsWhereOperator
+    | ContainsCaseInsensitiveWhereOperator
+    | NotContainsCaseInsensitiveWhereOperator
+    | StartsWithWhereOperator
+    | EndsWithWhereOperator
+    | EndsWithWhereOperator
+    | IsNullWhereOperator
+    | IsNotNullWhereOperator;
+
+type WhereClause<TKeys extends string = string, TValues = string> = Record<
+    TKeys,
+    WhereOperator<TValues>
+> &
+    OrWhereOperator<Record<TKeys, WhereOperator<TValues>>> &
+    AndWhereOperator<Record<TKeys, WhereOperator<TValues>>>;
+
+export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown, TPopulate = string[]> = {
+    where?: WhereClause<TFields>;
+    data?: TData;
+    offset?: number;
+    limit?: number;
+    populate?: TPopulate;
+    orderBy?: string | Array<unknown>;
+};
+
+export type StrapiAdmin = any;
 
 export type StrapiLog = {
-    log: Function
-    error: Function
-    warn: Function 
+    log: Function;
+    error: Function;
+    warn: Function;
 };
 
 export type StrapiRoute = {
-    method: Method
-    path: string
-    handler: string
-    config: StrapiRouteConfig
+    method: HTTPMethod;
+    path: string;
+    handler: string;
+    config: StrapiRouteConfig;
 };
 
 export type StrapiRouteConfig = {
-    policies: Array<string>
+    policies: Array<string>;
 };
 
 export type StrapiAdminUser = any;
@@ -141,6 +197,5 @@ export type StrapiAdminUser = any;
 export type StrapiUser = any;
 
 export type StrapiContext = {
-    strapi: IStrapi
-}
-
+    strapi: IStrapi;
+};


### PR DESCRIPTION
# What did you implement?

- typings for DB querying
- minor styling issues
- minor typing improvements (simplification, alternatives)

# How it can be tested?

Statement below should be valid and auto-completion should, well, autocomplete as you expand on this example.

```ts
type FooUser = {
  firstName: string,
  lastName: string,
  age: number,
}
type Foo = TypeResult<
    WhereClause<keyof FooUser, string | number>
>;
const foo: Foo = {
    firstName: "Lorem",
    lastName: {
        $containsi: "Ipsum",
    },
    $or: [
        {
            firstName: {
                $null: true,
            },
        },
        {
            age: {
                $gt: 9000
            }
        }
    ],
    $and: [
        {
            firstName: "Dull",
            lastName: {
                $notContains: "Boy",
            },
        },
    ],
};
```