### PR TITLE
feat: types for DB Query populate & select

### DIFF
--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -197,12 +197,17 @@ type WhereClause<TKeys extends string = string, TValues = Primitive> = Partial<
     AndWhereOperator<Record<TKeys, WhereOperator<TValues>>>
 >;
 
-export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown, TPopulate = string[]> = {
+type PopulateClause<TKeys extends string = string> = 
+    Partial<Record<TKeys, boolean | Array<string> | StringMap<unknown>>> |
+    Array<TKeys> | 
+    boolean;
+
+export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown> = {
     where?: WhereClause<OnlyStrings<TFields>>;
     data?: TData;
     offset?: number;
     limit?: number;
-    populate?: TPopulate;
+    populate?: PopulateClause<OnlyStrings<TFields>>;
     orderBy?: string | Array<unknown>;
 };
 

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -202,7 +202,11 @@ type PopulateClause<TKeys extends string = string> =
     Array<TKeys> | 
     boolean;
 
+
+type SelectClause<TKeys extends string = string> = TKeys | Array<TKeys> | '*';
+
 export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown> = {
+    select?: SelectClause<OnlyStrings<TFields>>;
     where?: WhereClause<OnlyStrings<TFields>>;
     data?: TData;
     offset?: number;


### PR DESCRIPTION
Let `populate` work by three different and supported ways:
- `boolean` like `populate: true`
- `array` like `populate: ['field1', 'field2']`
- `object` with field names of query type (nested) like: 
  ```ts
  {
     field: {
         nestedField: { ... }
     }
  }
  ```

And introduce the `select` property to DB query.