### PR TITLE
fix: where clause was too strict and demands all properties

### DIFF
--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -200,8 +200,8 @@ type WhereOperator<T = unknown> =
 
 type WhereClause<TKeys extends string = string, TValues = Primitive> = Partial<
   Record<TKeys, WhereOperator<TValues>> &
-    OrWhereOperator<Record<TKeys, WhereOperator<TValues>>> &
-    AndWhereOperator<Record<TKeys, WhereOperator<TValues>>>
+    OrWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>> &
+    AndWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>>
 >;
 
 type PopulateClause<TKeys extends string = string> = 


### PR DESCRIPTION
Fixes issue for constructions like:

```ts
   strapi.db
      .query<CommentReport>(getModelUid("comment-report"))
      .updateMany({
        where: {
          $and: [
            { id: ids },
            { related: commentId }
          ]
        },
        data: { resolved: true },
      });
```

Causing error like

`Type '{ id: Id[];  }' is missing the following properties from type 'Record<keyof CommentReport, WhereOperator<Primitive>>': related, content, reason, resolved`

That was because `$and` / `$or` weren't defined as `Partial<Record<...>>`