### PR TITLE
refactor: move declarations to ambient modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,24 @@ A developers goodie for [Strapi Headless CMS](https://github.com/strapi/strapi) 
 yarn add -D strapi-typed@latest
 ```
 
-and then use
+After install typings should be automatically available if you import from `@strapi/strapi`.
+
+If you want to use are internal utility types then use
 
 ```typescript
-import { IStrapi } from 'strapi-typed';
+import { StringMap, OnlyStrings } from "@strapi/typed";
+```
+
+In few place plugin creator or Strapi consumer can extend couple of interfaces to add custom typings
+
+For example
+
+```typescript
+declare module '@strapi/strapi' {
+  export interface IStrapiRequestQueryFiltersExtra {
+    threadOf?: number | string | null;
+  }
+}
 ```
 
 Enjoy 🎉

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,93 +1,150 @@
-import { StringMap, Primitive, TypeResult } from "./common";
-import { PopulateClause, StrapiUser } from "./core";
-import { OnlyStrings } from "./utils";
+import { StringMap, OnlyStrings, TypeResult, Primitive } from "@strapi/typed";
 
-type SendStrapiContextFunction = (...args: unknown[]) => void;
+declare module "@strapi/strapi" {
+  type SendStrapiContextFunction = (...args: unknown[]) => void;
 
-type ThrowStrapiContextFunction = (...args: unknown[]) => void;
+  type ThrowStrapiContextFunction = (...args: unknown[]) => void;
 
-type StrapiHTTPErrorConstructor<T = StringMap<unknown>> = (message?: string, details?: T) => any
+  type StrapiHTTPErrorConstructor<T = StringMap<unknown>> = (
+    message?: string,
+    details?: T
+  ) => any;
 
-export type StrapiRequestContext<
-  TBody extends {} = StringMap<string | number>,
-  TQuery extends {} = StringMap<string | number>,
-  TParams extends {} = StringMap<string | number>
-> = {
-  request: StrapiRequest<TBody>;
-  query: TQuery;
-  params: TParams;
-  pagination: StrapiPagination;
-  sort: StringMap<string | number>;
-  state: StrapiRequestContextState;
+  export type StrapiRequestContext<
+    TBody extends {} = StringMap<string | number>,
+    TQuery extends {} = StringMap<string | number>,
+    TParams extends {} = StringMap<string | number>
+  > = {
+    request: StrapiRequest<TBody>;
+    query: TQuery;
+    params: TParams;
+    pagination: StrapiPagination;
+    sort: StringMap<string | number>;
+    state: StrapiRequestContextState;
 
-  send: SendStrapiContextFunction;
-  throw: ThrowStrapiContextFunction;
+    send: SendStrapiContextFunction;
+    throw: ThrowStrapiContextFunction;
 
-  // @see {https://github.com/jshttp/http-errors#list-of-all-constructors}
-  notFound: StrapiHTTPErrorConstructor;
-  badRequest: StrapiHTTPErrorConstructor;
-  unauthorized: StrapiHTTPErrorConstructor;
-  methodNotAllowed: StrapiHTTPErrorConstructor;
-  internalServerError: StrapiHTTPErrorConstructor;
-  notImplemented: StrapiHTTPErrorConstructor;
-};
+    // @see {https://github.com/jshttp/http-errors#list-of-all-constructors}
+    notFound: StrapiHTTPErrorConstructor;
+    badRequest: StrapiHTTPErrorConstructor;
+    unauthorized: StrapiHTTPErrorConstructor;
+    methodNotAllowed: StrapiHTTPErrorConstructor;
+    internalServerError: StrapiHTTPErrorConstructor;
+    notImplemented: StrapiHTTPErrorConstructor;
+  };
 
-export type StrapiRequest<TBody extends {}> = {
-  body?: TBody;
-};
+  export type StrapiRequest<TBody extends {}> = {
+    body?: TBody;
+  };
 
-export type StrapiRequestContextState = {
-    user?: StrapiUser
-};
+  export type StrapiRequestContextState = {
+    user?: StrapiUser;
+  };
 
-export type StrapiRequestQuery<T, TFields = keyof T> = {
-  filters?: {
-    threadOf?: number | string | null;
-    [key: string]: any;
-  } & {};
-  populate?: StrapiRequestQueryPopulateClause<OnlyStrings<TFields>>;
-  sort?: StringMap<any>;
-  fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>;
-  pagination?: StrapiPagination;
-}
+  export type StrapiRequestQuery<T, TFields = keyof T> = {
+    filters?: {
+      threadOf?: number | string | null;
+      [key: string]: any;
+    } & {};
+    populate?: StrapiRequestQueryPopulateClause<OnlyStrings<TFields>>;
+    sort?: StringMap<any>;
+    fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>;
+    pagination?: StrapiPagination;
+  };
 
-export type StrapiRequestQueryFieldsClause<TKeys extends string = string> = Array<TKeys> | '*';
+  export type StrapiRequestQueryFieldsClause<TKeys extends string = string> =
+    | Array<TKeys>
+    | "*";
 
-export type StrapiRequestQueryPopulateClause<TKeys extends string = string> = PopulateClause<TKeys>;
-
-export type StrapiPagination = {
-  page?: number;
-  pageSize?: number;
-  start?: number;
-  limit?: number;
-  withCount?: boolean | string;
-};
-
-export type StrapiResponseMetaPagination = TypeResult<
-  Pick<StrapiPagination, "page" | "pageSize" | "start" | "limit"> & {
-    pageCount?: number;
-    total?: number;
+  export type StrapiRequestQueryPopulateClause<TKeys extends string = string> =
+    PopulateClause<TKeys>;
+  interface ISendStrapiContextFunction {
+    (...args: unknown[]): void;
   }
->;
 
-export type StrapiResponseMeta = {
-  pagination: StrapiResponseMetaPagination;
-};
+  interface IThrowStrapiContextFunction {
+    (...args: unknown[]): void;
+  }
 
-export type StrapiPaginatedResponse<T> = {
-  data: Array<T>;
-  meta?: StrapiResponseMeta;
-};
+  export interface IStrapiRequestContext<
+    TBody extends {} = StringMap<string | number>,
+    TQuery extends {} = StringMap<string | number>,
+    TParams extends {} = StringMap<string | number>
+  > {
+    request: StrapiRequest<TBody>;
+    query: TQuery;
+    params: TParams;
+    pagination: StrapiPagination;
+    sort: StringMap<string | number>;
+    state: StrapiRequestContextState;
 
-export type StrapiQueryParams = StringMap<string>;
+    send: ISendStrapiContextFunction;
+    throw: IThrowStrapiContextFunction;
+  }
 
-export type StrapiQueryParamsParsed = StringMap<Primitive>;
+  export interface IStrapiController<
+    TBody extends {} = StringMap<string | number>,
+    TQuery extends {} = StringMap<string | number>,
+    TParams extends {} = StringMap<string | number>,
+    TResult = unknown
+  > {
+    (ctx: IStrapiRequestContext<TBody, TQuery, TParams>): TResult;
+  }
 
-export type StrapiQueryParamsParsedOrderBy = string | Array<string>;
+  export interface IStrapiRequestQueryFiltersExtra {}
 
-type StrapiQueryParamsParsedFilterValue<TKeys extends string = string> =
-  | Primitive
-  | Partial<Record<TKeys, unknown>>;
+  export interface IStrapiRequestQuery<T, TFields = keyof T> {
+    filters?: {
+      [key: string]: any;
+    } & IStrapiRequestQueryFiltersExtra;
+    populate?: StrapiRequestQueryPopulateClause<OnlyStrings<TFields>>;
+    sort?: StringMap<any>;
+    fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>;
+    pagination?: StrapiPagination;
+  }
 
-export type StrapiQueryParamsParsedFilters<TValue, TKeys = keyof TValue> = 
-Partial<Record<OnlyStrings<TKeys>, StrapiQueryParamsParsedFilterValue<OnlyStrings<TKeys>>>>;
+  export type StrapiPagination = {
+    page?: number;
+    pageSize?: number;
+    start?: number;
+    limit?: number;
+    withCount?: boolean | string;
+  };
+
+  export type StrapiResponseMetaPagination = TypeResult<
+    Pick<StrapiPagination, "page" | "pageSize" | "start" | "limit"> & {
+      pageCount?: number;
+      total?: number;
+    }
+  >;
+
+  export type StrapiResponseMeta = {
+    pagination: StrapiResponseMetaPagination;
+  };
+
+  export type StrapiPaginatedResponse<T> = {
+    data: Array<T>;
+    meta?: StrapiResponseMeta;
+  };
+
+  export type StrapiQueryParams = StringMap<string>;
+
+  export type StrapiQueryParamsParsed = StringMap<Primitive>;
+
+  export type StrapiQueryParamsParsedOrderBy = string | Array<string>;
+
+  type StrapiQueryParamsParsedFilterValue<TKeys extends string = string> =
+    | Primitive
+    | Partial<Record<TKeys, unknown>>;
+
+  export type StrapiQueryParamsParsedFilters<
+    TValue,
+    TKeys = keyof TValue
+  > = Partial<
+    Record<
+      OnlyStrings<TKeys>,
+      StrapiQueryParamsParsedFilterValue<OnlyStrings<TKeys>>
+    >
+  >;
+}

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -1,15 +1,17 @@
-export type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
+declare module "@strapi/typed" {
+  export type PropType<TObj, TProp extends keyof TObj> = TObj[TProp];
 
-export type Primitive = string | number | object | boolean | null | undefined;
+  export type Primitive = string | number | object | boolean | null | undefined;
 
-export type KeyValueSet<T> = Record<string, T | any>;
+  export type KeyValueSet<T> = Record<string, T | any>;
 
-export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+  export type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
-export type StringMap<Type> = Record<string, Type>;
+  export type StringMap<Type> = Record<string, Type>;
 
-export type TypeResult<T> = {
-  [K in keyof T]: T[K];
-};
+  export type TypeResult<T> = {
+    [K in keyof T]: T[K];
+  };
 
-export type Id = number | string;
+  export type Id = number | string;
+}

--- a/types/contentType.ts
+++ b/types/contentType.ts
@@ -1,110 +1,115 @@
-import { Primitive, StringMap } from "./common";
+import { Primitive, StringMap } from "@strapi/typed";
 
-export type ContentType = "collectionType" | "singleType";
+declare module "@strapi/strapi" {
+  export type ContentType = "collectionType" | "singleType";
 
-export type StrapiContentTypeInfo = {
-  singularName: string;
-  pluralName: string;
-  displayName: string;
-  description: string;
-};
+  export interface IStrapiContentTypeInfo {
+    singularName: string;
+    pluralName: string;
+    displayName: string;
+    description: string;
+  }
 
-export type StrapiContentTypeAttributeValidator = {
-  required?: boolean;
-  max?: number;
-  min?: number;
-  minLength?: number;
-  maxLength?: number;
-  private?: boolean;
-  configurable?: boolean;
-  default?: Primitive;
-};
-export type SimpleStrapiContentTypeAttributeKeys =
-  | "string"
-  | "text"
-  | "richtext"
-  | "email"
-  | "password"
-  | "date"
-  | "time"
-  | "datetime"
-  | "timestamp"
-  | "boolean"
-  | "integer"
-  | "biginteger"
-  | "float"
-  | "decimal"
-  | "json";
+  export interface IStrapiContentTypeAttributeValidator {
+    required?: boolean;
+    max?: number;
+    min?: number;
+    minLength?: number;
+    maxLength?: number;
+    private?: boolean;
+    configurable?: boolean;
+    default?: Primitive;
+  }
 
-export type SimpleStrapiContentTypeAttribute = {
-  type: SimpleStrapiContentTypeAttributeKeys;
-} & StrapiContentTypeAttributeValidator;
+  export type SimpleStrapiContentTypeAttributeKeys =
+    | "string"
+    | "text"
+    | "richtext"
+    | "email"
+    | "password"
+    | "date"
+    | "time"
+    | "datetime"
+    | "timestamp"
+    | "boolean"
+    | "integer"
+    | "biginteger"
+    | "float"
+    | "decimal"
+    | "json";
 
-export type StrapiContentTypeEnumerationAttribute = {
-  type: "enumeration";
-  enum: Array<string>;
-} & StrapiContentTypeAttributeValidator;
+  export type SimpleStrapiContentTypeAttribute = {
+    type: SimpleStrapiContentTypeAttributeKeys;
+  } & IStrapiContentTypeAttributeValidator;
 
-export type StrapiContentTypeComponentAttribute = {
-  type: "component";
-  component: string;
-  repeatable?: boolean;
-};
+  export type StrapiContentTypeEnumerationAttribute = {
+    type: "enumeration";
+    enum: Array<string>;
+  } & IStrapiContentTypeAttributeValidator;
 
-export type StrapiContentTypeDynamicZoneAttribute = {
-  type: "dynamiczone";
-  components: Array<string>;
-};
+  export type StrapiContentTypeComponentAttribute = {
+    type: "component";
+    component: string;
+    repeatable?: boolean;
+  };
 
-export type StrapiContentTypeMediaAttribute = {
-  type: "media";
-  allowedTypes: Array<"images" | "videos" | "files">;
-  required?: boolean;
-};
+  export type StrapiContentTypeDynamicZoneAttribute = {
+    type: "dynamiczone";
+    components: Array<string>;
+  };
 
-export type StrapiContentTypeUIDAttribute<T extends string = string> = {
-  type: "uid";
-  targetField: T;
-  options: string;
-};
+  export type StrapiContentTypeMediaAttribute = {
+    type: "media";
+    allowedTypes: Array<"images" | "videos" | "files">;
+    required?: boolean;
+  };
 
-export type StrapiContentTypeRelationType =
-  | "oneToOne"
-  | "oneToMany"
-  | "manyToOne"
-  | "manyToMany";
+  export type StrapiContentTypeUIDAttribute<T extends string = string> = {
+    type: "uid";
+    targetField: T;
+    options: string;
+  };
 
-export type StrapiContentTypeRelationAttribute = {
-  type: "relation";
-  relation: StrapiContentTypeRelationType;
-  target: string;
-  mappedBy?: string;
-  inversedBy?: string;
-};
+  export type StrapiContentTypeRelationType =
+    | "oneToOne"
+    | "oneToMany"
+    | "manyToOne"
+    | "manyToMany";
 
-export type StrapiContentTypeAttributes<T extends string = string> = Record<
-  T,
-  | SimpleStrapiContentTypeAttribute
-  | StrapiContentTypeEnumerationAttribute
-  | StrapiContentTypeComponentAttribute
-  | StrapiContentTypeDynamicZoneAttribute
-  | StrapiContentTypeRelationAttribute
-  | StrapiContentTypeMediaAttribute
->;
+  export type StrapiContentTypeRelationAttribute = {
+    type: "relation";
+    relation: StrapiContentTypeRelationType;
+    target: string;
+    mappedBy?: string;
+    inversedBy?: string;
+  };
 
-export type StrapiContentTypeFullSchema<TAttributes extends string = string> = {
-  kind: ContentType;
-  collectionName: string;
-  info: StrapiContentTypeInfo;
-  options: StringMap<Primitive>;
-  attributes: StrapiContentTypeAttributes<TAttributes>;
-  actions: StringMap<unknown>;
-  lifecycles: StringMap<unknown>;
-  uid: string;
-  apiName: string;
-};
+  export type StrapiContentTypeAttributes<T extends string = string> = Record<
+    T,
+    | SimpleStrapiContentTypeAttribute
+    | StrapiContentTypeEnumerationAttribute
+    | StrapiContentTypeComponentAttribute
+    | StrapiContentTypeDynamicZoneAttribute
+    | StrapiContentTypeRelationAttribute
+    | StrapiContentTypeMediaAttribute
+  >;
 
-export type StrapiContentTypeSchema<TAttributes extends string = string> = Pick<
-  StrapiContentTypeFullSchema<TAttributes>,
-  "info" | "kind" | "attributes" | "options"
->;
+  export type StrapiContentTypeFullSchema<TAttributes extends string = string> =
+    {
+      kind: ContentType;
+      collectionName: string;
+      info: IStrapiContentTypeInfo;
+      options: StringMap<Primitive>;
+      attributes: StrapiContentTypeAttributes<TAttributes>;
+      actions: StringMap<unknown>;
+      lifecycles: StringMap<unknown>;
+      uid: string;
+      apiName: string;
+    };
+
+  export type StrapiContentTypeSchema<TAttributes extends string = string> =
+    Pick<
+      StrapiContentTypeFullSchema<TAttributes>,
+      "info" | "kind" | "attributes" | "options"
+    >;
+}

--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -1,10 +1,14 @@
-import { EventEmitter } from "events";
-import { StrapiRequestContext } from "./api";
-import { HTTPMethod, Primitive, StringMap, TypeResult } from "./common";
-import { StrapiContentTypeFullSchema, StrapiContentTypeSchema } from "./contentType";
-import { OnlyStrings } from "./utils";
+declare module "@strapi/strapi" {
+  import { EventEmitter } from "events";
+  import { StrapiRequestContext } from "./api";
+  import { HTTPMethod, Primitive, StringMap, TypeResult } from "./common";
+  import {
+    StrapiContentTypeFullSchema,
+    StrapiContentTypeSchema,
+  } from "./contentType";
+  import { OnlyStrings } from "./utils";
 
-export interface IStrapi {
+  export interface IStrapi {
     config: StrapiConfigContainer;
     EE(): Function;
     get services(): StringMap<StrapiService>;
@@ -57,53 +61,57 @@ export interface IStrapi {
     db: StrapiDB;
     admin: StrapiAdmin;
     log: StrapiLog;
-}
+  }
 
-export type StrapiEvents = `${'entry' | 'media'}.${StrapiEventsCrudFlow}` | `entry.${StrapiEventsPublishFlow}`;
-type StrapiEventsCrudFlow = 'create' | 'update' | 'delete';
-type StrapiEventsPublishFlow = 'publish' | 'unpublish';
+  export type StrapiEvents =
+    | `${"entry" | "media"}.${StrapiEventsCrudFlow}`
+    | `entry.${StrapiEventsPublishFlow}`;
+  type StrapiEventsCrudFlow = "create" | "update" | "delete";
+  type StrapiEventsPublishFlow = "publish" | "unpublish";
 
-export type StrapiService = any;
-export type StrapiController<
-    TResult = unknown, 
+  export type StrapiService = any;
+  export type StrapiController<
+    TResult = unknown,
     TBody extends {} = StringMap<string | number>,
     TQuery extends {} = StringMap<string | number>,
     TParams extends {} = StringMap<string | number>,
     TContextExtra extends {} = {}
-> = (context: StrapiRequestContext<TBody, TQuery, TParams> & TContextExtra) => TResult
-export type StrapiMiddleware = Object;
-export type StrapiContentType<T extends StrapiContentTypeSchema> = T;
-export type StrapiPolicy = Object;
-export type StrapiHook = Object;
+  > = (
+    context: StrapiRequestContext<TBody, TQuery, TParams> & TContextExtra
+  ) => TResult;
+  export type StrapiMiddleware = Object;
+  export type StrapiContentType<T extends StrapiContentTypeSchema> = T;
+  export type StrapiPolicy = Object;
+  export type StrapiHook = Object;
 
-export type StrapiWebhook = {
-  id?: Id,
-  name: string,
-  type: string,
-  url: string,
-  headers: StringMap<string>,
-  events: StrapiEvents[],
-  enabled: boolean,
-} 
-export type StrapiWebhookRunner = {
-  config: StringMap<unknown>,
-  eventHub: EventEmitter,
-  listeners: Map<StrapiEvents, Function>,
-  logger: unknown,
-  queue: unknown,
-  webhooksMap: Map<StrapiEvents, StrapiWebhook[]>,
-};
-export type StrapiWebhookStore = {
-  createWebhook: (data: StrapiWebhook) => any
-  deleteWebhook: (id) => any
-  findWebhook: (id) => StrapiWebhook
-  findWebhooks: () => StrapiWebhook[]
-  updateWebhook: (data: StrapiWebhook) => any
-}
+  export type StrapiWebhook = {
+    id?: Id;
+    name: string;
+    type: string;
+    url: string;
+    headers: StringMap<string>;
+    events: StrapiEvents[];
+    enabled: boolean;
+  };
+  export type StrapiWebhookRunner = {
+    config: StringMap<unknown>;
+    eventHub: EventEmitter;
+    listeners: Map<StrapiEvents, Function>;
+    logger: unknown;
+    queue: unknown;
+    webhooksMap: Map<StrapiEvents, StrapiWebhook[]>;
+  };
+  export type StrapiWebhookStore = {
+    createWebhook: (data: StrapiWebhook) => any;
+    deleteWebhook: (id) => any;
+    findWebhook: (id) => StrapiWebhook;
+    findWebhooks: () => StrapiWebhook[];
+    updateWebhook: (data: StrapiWebhook) => any;
+  };
 
-export type StrapiApi = Object;
-export type StrapiAuth = Object;
-export type StrapiPlugin = {
+  export type StrapiApi = Object;
+  export type StrapiAuth = Object;
+  export type StrapiPlugin = {
     get services(): StringMap<StrapiService>;
     service(uid: string): StrapiService;
     get controllers(): StringMap<StrapiController>;
@@ -111,73 +119,79 @@ export type StrapiPlugin = {
     get contentTypes(): StringMap<any>;
     contentType(name: string): StrapiContentType;
     config(name: string): any;
-};
+  };
 
-export type StrapiPluginConfig<T> = TypeResult<T>;
+  export type StrapiPluginConfig<T> = TypeResult<T>;
 
-export type StrapiConfigContainer = StringMap<any> & {
+  export type StrapiConfigContainer = StringMap<any> & {
     get: Function;
-};
+  };
 
-export type StrapiStore = {
+  export type StrapiStore = {
     get: <T extends string = string, U = unknown>({ key: T }) => U;
     set: <T extends string = string, U = unknown>({ key: T, value: U }) => void;
     delete: <T extends string = string>({ key: T }) => void;
-};
+  };
 
-export type StrapiStoreQuery = {
+  export type StrapiStoreQuery = {
     type: string;
     name?: string;
-};
+  };
 
-export type StrapiDB = {
+  export type StrapiDB = {
     query<T>(uid: string): StrapiDBQuery<T>;
-};
+  };
 
-export type StrapiDBQuery<TValue, TKeys = keyof TValue> = {
+  export type StrapiDBQuery<TValue, TKeys = keyof TValue> = {
     findOne(args: number | string | StrapiDBQueryArgs<TKeys>): Promise<TValue>;
     findMany(args?: StrapiDBQueryArgs<TKeys>): Promise<Array<TValue>>;
     findWithCount(
-        args: StrapiDBQueryArgs<TKeys>
+      args: StrapiDBQueryArgs<TKeys>
     ): Promise<[items: Array<TValue>, count: number]>;
     create(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
-    createMany(args: StrapiDBQueryArgs<TKeys>): Promise<StrapiDBBulkActionResponse>;
+    createMany(
+      args: StrapiDBQueryArgs<TKeys>
+    ): Promise<StrapiDBBulkActionResponse>;
     update(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
-    updateMany(args: StrapiDBQueryArgs<TKeys>): Promise<StrapiDBBulkActionResponse>;
+    updateMany(
+      args: StrapiDBQueryArgs<TKeys>
+    ): Promise<StrapiDBBulkActionResponse>;
     delete(args: StrapiDBQueryArgs<TKeys>): Promise<TValue>;
-    deleteMany(args: StrapiDBQueryArgs<TKeys>): Promise<StrapiDBBulkActionResponse>;
+    deleteMany(
+      args: StrapiDBQueryArgs<TKeys>
+    ): Promise<StrapiDBBulkActionResponse>;
     count(args?: StrapiDBQueryArgs<TKeys>): number;
-};
+  };
 
-// https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.html#logical-operators
+  // https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/filtering.html#logical-operators
 
-type EqualWhereOperator<T = unknown> = { $eq: T };
-type NotEqualWhereOperator<T = unknown> = { $ne: T };
-type InWhereOperator<T = string> = { $in: Array<T> };
-type NotInWhereOperator<T = string> = { $notIn: Array<T> };
-type LessThanWhereOperator = { $lt: number };
-type LessThanEqualWhereOperator = { $lte: number };
-type GreaterThanWhereOperator = { $gt: number };
-type GreaterThanEqualWhereOperator = { $gte: number };
-type BetweenWhereOperator = { $between: Array<number> };
-type ContainsWhereOperator = { $contains: string };
-type NotContainsWhereOperator = { $notContains: string };
-type ContainsCaseInsensitiveWhereOperator = { $containsi: string };
-type NotContainsCaseInsensitiveWhereOperator = { $notContainsi: string };
-type StartsWithWhereOperator = { $startsWith: string };
-type EndsWithWhereOperator = { $endsWith: string };
-type EndsWithWhereOperator = { $endsWith: string };
-type IsNullWhereOperator = { $null: boolean };
-type IsNotNullWhereOperator = { $notNull: boolean };
-type NotWhereOperator<TKey extends string, TValue> = {
+  type EqualWhereOperator<T = unknown> = { $eq: T };
+  type NotEqualWhereOperator<T = unknown> = { $ne: T };
+  type InWhereOperator<T = string> = { $in: Array<T> };
+  type NotInWhereOperator<T = string> = { $notIn: Array<T> };
+  type LessThanWhereOperator = { $lt: number };
+  type LessThanEqualWhereOperator = { $lte: number };
+  type GreaterThanWhereOperator = { $gt: number };
+  type GreaterThanEqualWhereOperator = { $gte: number };
+  type BetweenWhereOperator = { $between: Array<number> };
+  type ContainsWhereOperator = { $contains: string };
+  type NotContainsWhereOperator = { $notContains: string };
+  type ContainsCaseInsensitiveWhereOperator = { $containsi: string };
+  type NotContainsCaseInsensitiveWhereOperator = { $notContainsi: string };
+  type StartsWithWhereOperator = { $startsWith: string };
+  type EndsWithWhereOperator = { $endsWith: string };
+  type EndsWithWhereOperator = { $endsWith: string };
+  type IsNullWhereOperator = { $null: boolean };
+  type IsNotNullWhereOperator = { $notNull: boolean };
+  type NotWhereOperator<TKey extends string, TValue> = {
     $not: {
-        [TKey]: [TValue];
+      [TKey]: [TValue];
     };
-};
-type AndWhereOperator<T> = { $and: T[] };
-type OrWhereOperator<T> = { $or: T[] };
+  };
+  type AndWhereOperator<T> = { $and: T[] };
+  type OrWhereOperator<T> = { $or: T[] };
 
-type WhereOperator<T = unknown> =
+  type WhereOperator<T = unknown> =
     | T
     | EqualWhereOperator<T>
     | NotEqualWhereOperator<T>
@@ -198,21 +212,26 @@ type WhereOperator<T = unknown> =
     | IsNullWhereOperator
     | IsNotNullWhereOperator;
 
-type WhereClause<TKeys extends string = string, TValues = Primitive> = Partial<
-  Record<TKeys, WhereOperator<TValues>> &
-    OrWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>> &
-    AndWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>>
->;
+  type WhereClause<
+    TKeys extends string = string,
+    TValues = Primitive
+  > = Partial<
+    Record<TKeys, WhereOperator<TValues>> &
+      OrWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>> &
+      AndWhereOperator<Partial<Record<TKeys, WhereOperator<TValues>>>>
+  >;
 
-type PopulateClause<TKeys extends string = string> = 
-    Partial<Record<TKeys, boolean | Array<string> | StringMap<unknown>>> |
-    Array<TKeys> | 
-    boolean;
+  type PopulateClause<TKeys extends string = string> =
+    | Partial<Record<TKeys, boolean | Array<string> | StringMap<unknown>>>
+    | Array<TKeys>
+    | boolean;
 
+  type SelectClause<TKeys extends string = string> = TKeys | Array<TKeys> | "*";
 
-type SelectClause<TKeys extends string = string> = TKeys | Array<TKeys> | '*';
-
-export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown> = {
+  export type StrapiDBQueryArgs<
+    TFields extends string = string,
+    TData = unknown
+  > = {
     select?: SelectClause<OnlyStrings<TFields>>;
     where?: WhereClause<OnlyStrings<TFields>>;
     data?: TData;
@@ -220,47 +239,48 @@ export type StrapiDBQueryArgs<TFields extends string = string, TData = unknown> 
     limit?: number;
     populate?: PopulateClause<OnlyStrings<TFields>>;
     orderBy?: string | Array<unknown>;
-};
+  };
 
-export type StrapiDBBulkActionResponse = {
+  export type StrapiDBBulkActionResponse = {
     count: number;
-};
+  };
 
-export type StrapiAdmin = any;
+  export type StrapiAdmin = any;
 
-export type StrapiLog = {
+  export type StrapiLog = {
     log: Function;
     error: Function;
     warn: Function;
-};
+  };
 
-export type StrapiRoute = {
+  export type StrapiRoute = {
     method: HTTPMethod;
     path: string;
     handler: string;
     config: StrapiRouteConfig;
-};
+  };
 
-export type StrapiRouteConfig = {
+  export type StrapiRouteConfig = {
     policies: Array<string>;
     description?: string;
-    tag?: StrapiRouteConfigTag; 
-};
+    tag?: StrapiRouteConfigTag;
+  };
 
-export type StrapiRouteConfigTag = {
+  export type StrapiRouteConfigTag = {
     plugin: string;
     name?: string;
     actionType?: string;
-};
+  };
 
-export type StrapiAdminUser = any;
+  export type StrapiAdminUser = any;
 
-export type StrapiUser = {
+  export type StrapiUser = {
     id: Id;
     email: string;
     username: string;
-} & StringMap<unknown>;
+  } & StringMap<unknown>;
 
-export type StrapiContext = {
+  export type StrapiContext = {
     strapi: IStrapi;
-};
+  };
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-export * from './common';
-export * from './contentType';
-export * from './core';
-export * from './api';
-export * from './utils';
+import "./common";
+import "./contentType";
+import "./core";
+import "./api";
+import "./utils";

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -1,1 +1,3 @@
-export type OnlyStrings<T> = T extends string ? T : never;
+declare module "@strapi/typed" {
+  export type OnlyStrings<T> = T extends string ? T : never;
+}


### PR DESCRIPTION
## What did you implement

- move of declarations to ambient modules to enable interface merging
- this is a **BREAKING CHANGE**

## How can I test it?

- symbolic link repository to node_modules of your plugin/server
- types are available at `@strapi/strapi` and `@strapi/typed`