### PR TITLE
feat: Add type for strapi.cron

### DIFF
--- a/types/core.d.ts
+++ b/types/core.d.ts
@@ -59,6 +59,7 @@ export interface IStrapi {
     db: StrapiDB;
     admin: StrapiAdmin;
     log: StrapiLog;
+    cron: StrapiCron;
 
     customFields: StrapiServerCustomFields;
 }
@@ -243,6 +244,12 @@ export type StrapiLog = {
     log: Function;
     error: Function;
     warn: Function;
+};
+
+export type StrapiCron = {
+    add: Function;
+    remove: Function;
+    jobs: any[];
 };
 
 export type AllowedCustomFieldType =


### PR DESCRIPTION
Adds a type for `strapi.cron`.

Also I was wondering if you've ever tried to merge these types back to the main Strapi repository?
It would be great if the `IStrapi` type would just be the main `Strapi` type.